### PR TITLE
Correcting the installation of the ethos-u-vela library

### DIFF
--- a/notebooks/Google-Colab-PFLD-Grove-Example.ipynb
+++ b/notebooks/Google-Colab-PFLD-Grove-Example.ipynb
@@ -53,7 +53,6 @@
       "outputs": [],
       "source": [
         "# Ethos-U-Vela need to be installed this way, or SSCMA does not work anymore...\n",
-        "%env PYTHON_EXEC=python3.8\n",
         "!git clone https://review.mlplatform.org/ml/ethos-u/ethos-u-vela.git\n",
         "%cd ethos-u-vela\n",
         "!pip install .\n",

--- a/notebooks/Google-Colab-PFLD-Grove-Example.ipynb
+++ b/notebooks/Google-Colab-PFLD-Grove-Example.ipynb
@@ -1,13 +1,12 @@
 {
   "cells": [
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "mNESTCLfvSrY"
       },
       "source": [
-        "# Welcom to SSCMA for Google Colab Training Example 🔥 \n",
+        "# Welcom to SSCMA for Google Colab Training Example 🔥\n",
         "\n",
         "<a href=\"https://colab.research.google.com/github/Seeed-Studio/SSCMA/blob/main/notebooks/Google-Colab-PFLD-Grove-Example.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a> **[🚀🚀🚀 One-Click to Deploy to Google Colab 🚀🚀🚀](https://colab.research.google.com/github/Seeed-Studio/SSCMA/blob/main/notebooks/Google-Colab-PFLD-Grove-Example.ipynb)**\n",
         "\n",
@@ -28,7 +27,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "PRGi8-2jvxzR"
@@ -38,7 +36,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "Ikzx6C6wrpos"
@@ -51,14 +48,18 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "F5pMIwXuvPpG",
-        "outputId": "d66ee6b7-6398-4d0a-a78b-4cf294a4b4e2"
+        "id": "F5pMIwXuvPpG"
       },
       "outputs": [],
       "source": [
+        "# Ethos-U-Vela need to be installed this way, or SSCMA does not work anymore...\n",
+        "%env PYTHON_EXEC=python3.8\n",
+        "!git clone https://review.mlplatform.org/ml/ethos-u/ethos-u-vela.git\n",
+        "%cd ethos-u-vela\n",
+        "!pip install .\n",
+        "%cd ..\n",
+        "\n",
+        "# Now it works...\n",
         "!git clone https://github.com/Seeed-Studio/SSCMA.git  # currently we're using experimental 2.0 version branch"
       ]
     },
@@ -66,11 +67,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "-4H83YK8waNA",
-        "outputId": "1f8ea61f-132e-4d42-c336-d8c3eabbda8b"
+        "id": "-4H83YK8waNA"
       },
       "outputs": [],
       "source": [
@@ -78,7 +75,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "LWAE--J9sAmW"
@@ -91,11 +87,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "STOKRHwXs70f",
-        "outputId": "1afa4628-764c-4edf-bb13-261f3b0e4786"
+        "id": "STOKRHwXs70f"
       },
       "outputs": [],
       "source": [
@@ -106,11 +98,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "xF4nReUbqbUA",
-        "outputId": "2bf0b960-152c-49ad-a4c8-79269a9c2a82"
+        "id": "xF4nReUbqbUA"
       },
       "outputs": [],
       "source": [
@@ -119,7 +107,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "zX3aW3Rys1Zr"
@@ -132,11 +119,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "k1HIXVgCzrCz",
-        "outputId": "074841fc-12c1-4ead-a391-1a5bc2fe902e"
+        "id": "k1HIXVgCzrCz"
       },
       "outputs": [],
       "source": [
@@ -145,7 +128,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "v47-pxMe2DP1"
@@ -155,7 +137,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "90NL7Kg-vxy7"
@@ -170,11 +151,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "oSJZdF4l2JEe",
-        "outputId": "8bc4111f-ee71-4e08-ad0b-68c9a509d02b"
+        "id": "oSJZdF4l2JEe"
       },
       "outputs": [],
       "source": [
@@ -183,7 +160,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "2HMAOOWR2sf6"
@@ -193,7 +169,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "zmWPp53tcLpB"
@@ -210,11 +185,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "J7TrWv8_wjXY",
-        "outputId": "1d6f4ec0-dec4-417c-908e-ed4314c73303"
+        "id": "J7TrWv8_wjXY"
       },
       "outputs": [],
       "source": [
@@ -222,7 +193,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "l61rdIv_Z59j"
@@ -235,19 +205,14 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "lEN9rtggW7yt",
-        "outputId": "688d94c9-a4a0-4265-809e-872cdb02772f"
+        "id": "lEN9rtggW7yt"
       },
       "outputs": [],
       "source": [
-        "!wget -P pre-train/ https://github.com/Seeed-Studio/SSCMA/releases/download/model_zoo/pfld_mbv2n_112.pth "
+        "!wget -P pre-train/ https://github.com/Seeed-Studio/SSCMA/releases/download/model_zoo/pfld_mbv2n_112.pth"
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "Y9sSOwrZdaLo"
@@ -270,11 +235,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "zUgKXe2s2wto",
-        "outputId": "48c35897-3936-4772-b9bf-c33b4efc04e0"
+        "id": "zUgKXe2s2wto"
       },
       "outputs": [],
       "source": [
@@ -288,7 +249,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "tGl9VBZavSmM"
@@ -301,11 +261,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "Ff8MtMaSu8Ij",
-        "outputId": "06ce3142-4d4e-410b-9417-c87f1a4feed2"
+        "id": "Ff8MtMaSu8Ij"
       },
       "outputs": [],
       "source": [
@@ -313,7 +269,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "m4Y6DM16vgLF"
@@ -326,11 +281,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "RMf9sHP2vNzW",
-        "outputId": "e0dceb1f-678a-4c3c-9d4c-86a7f324f5ea"
+        "id": "RMf9sHP2vNzW"
       },
       "outputs": [],
       "source": [
@@ -338,7 +289,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "G7KqGi2OxnaM"
@@ -353,11 +303,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "v5SckZpKx21c",
-        "outputId": "86e0d575-60ad-45de-fe3a-9a9efb86ffcd"
+        "id": "v5SckZpKx21c"
       },
       "outputs": [],
       "source": [
@@ -373,11 +319,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "5vk0o2HAyaz7",
-        "outputId": "8341030e-3843-4e48-92ea-bc771d5bc746"
+        "id": "5vk0o2HAyaz7"
       },
       "outputs": [],
       "source": [
@@ -390,7 +332,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "5np32KYq8JL4"
@@ -400,7 +341,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "QF9ObhTrjwI2"
@@ -415,11 +355,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "a50cBz7P8TP-",
-        "outputId": "28ad830a-19f0-4707-91fb-25b7d74af05a"
+        "id": "a50cBz7P8TP-"
       },
       "outputs": [],
       "source": [
@@ -432,7 +368,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "akUdGWE-1Z-8"
@@ -446,7 +381,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "1huhlfmt3np4"
@@ -459,11 +393,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "7hIBg6T73Ro3",
-        "outputId": "2d364830-dbf8-4c3f-b02e-cc87689c0c68"
+        "id": "7hIBg6T73Ro3"
       },
       "outputs": [],
       "source": [
@@ -485,11 +415,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "WDBzyjFL7RHN",
-        "outputId": "a48069c6-040d-4836-b5cc-a6f0f0681ed6"
+        "id": "WDBzyjFL7RHN"
       },
       "outputs": [],
       "source": [
@@ -502,7 +428,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "ZMSi7Ie--O1h"
@@ -515,11 +440,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "vD6cIBo9-WPA",
-        "outputId": "aca85b23-795f-4e93-9a63-0187802c81cd"
+        "id": "vD6cIBo9-WPA"
       },
       "outputs": [],
       "source": [
@@ -541,11 +462,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "SZ0UyC7HA1zH",
-        "outputId": "a8d67db3-62b8-4ee6-9901-31211a5b6ab7"
+        "id": "SZ0UyC7HA1zH"
       },
       "outputs": [],
       "source": [
@@ -553,7 +470,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "IGHvs_2n--gP"
@@ -566,11 +482,7 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "18TRCN-z-r3_",
-        "outputId": "6483334d-e5c0-46fe-cbde-e16032bbed8f"
+        "id": "18TRCN-z-r3_"
       },
       "outputs": [],
       "source": [
@@ -579,7 +491,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "6ISXUUG2_uKY"
@@ -628,7 +539,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "2zrBJSg0FST3"
@@ -675,7 +585,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "_4cVSi76EsFg"
@@ -689,7 +598,6 @@
       ]
     },
     {
-      "attachments": {},
       "cell_type": "markdown",
       "metadata": {
         "id": "qasiYT2qJWPm"

--- a/notebooks/Google-Colab-PFLD-Grove-Example.ipynb
+++ b/notebooks/Google-Colab-PFLD-Grove-Example.ipynb
@@ -6,7 +6,7 @@
         "id": "mNESTCLfvSrY"
       },
       "source": [
-        "# Welcom to SSCMA for Google Colab Training Example 🔥\n",
+        "# Welcome to SSCMA for Google Colab Training Example 🔥\n",
         "\n",
         "<a href=\"https://colab.research.google.com/github/Seeed-Studio/SSCMA/blob/main/notebooks/Google-Colab-PFLD-Grove-Example.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a> **[🚀🚀🚀 One-Click to Deploy to Google Colab 🚀🚀🚀](https://colab.research.google.com/github/Seeed-Studio/SSCMA/blob/main/notebooks/Google-Colab-PFLD-Grove-Example.ipynb)**\n",
         "\n",

--- a/notebooks/Google-Colab-SWFIT-YOLO-A1101-Example.ipynb
+++ b/notebooks/Google-Colab-SWFIT-YOLO-A1101-Example.ipynb
@@ -53,10 +53,10 @@
       "outputs": [],
       "source": [
         "# Ethos-U-Vela need to be installed this way, or SSCMA does not work anymore...\n",
-        "!git clone https://review.mlplatform.org/ml/ethos-u/ethos-u-vela.git",
-        "%cd ethos-u-vela",
-        "!pip install .",
-        "%cd..",
+        "!git clone https://review.mlplatform.org/ml/ethos-u/ethos-u-vela.git\n",
+        "%cd ethos-u-vela\n",
+        "!pip install .\n",
+        "%cd..\n",
         "!git clone https://github.com/Seeed-Studio/SSCMA.git  # currently we're using experimental 2.0 version branch\n",
         "%cd /content/SSCMA"
       ]

--- a/notebooks/Google-Colab-SWFIT-YOLO-A1101-Example.ipynb
+++ b/notebooks/Google-Colab-SWFIT-YOLO-A1101-Example.ipynb
@@ -52,6 +52,11 @@
       },
       "outputs": [],
       "source": [
+        "# Ethos-U-Vela need to be installed this way, or SSCMA does not work anymore...\n",
+        "!git clone https://review.mlplatform.org/ml/ethos-u/ethos-u-vela.git",
+        "%cd ethos-u-vela",
+        "!pip install .",
+        "%cd..",
         "!git clone https://github.com/Seeed-Studio/SSCMA.git  # currently we're using experimental 2.0 version branch\n",
         "%cd /content/SSCMA"
       ]


### PR DESCRIPTION
Correcting the installation of the ethos-u-vela library that is not being done correctly via pip in the installation script.

The ethos-u-vela library was not being installed via pip due to some inconsistency in the metadata. Tested only on Google Colab.

At the beginning of the Notebook add the commands:

```
# Ethos-U-Vela need to be installed this way, or SSCMA does not work anymore...
!git clone https://review.mlplatform.org/ml/ethos-u/ethos-u-vela.git
%cd ethos-u-vela
!pip install .
%cd..
```