### PR TITLE
fix: bump min Python to 3.11 in smoke-test and conda env

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -34,9 +34,9 @@ jobs:
           - ubuntu-latest
           - windows-latest
         python-version:
-          - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
     defaults:
       run:
         shell: bash -l {0}

--- a/environment.yml
+++ b/environment.yml
@@ -4,5 +4,5 @@ channels:
   - defaults
 
 dependencies:
-  - python>=3.8, <= 3.10
+  - python>=3.11
   - pip>=23.0.1


### PR DESCRIPTION
## Summary

smoke-test was failing because:
- Python 3.10 in the test matrix can't install scikit-image>=0.26, scikit-learn>=1.8, tensorboard>=2.20 (all require Python>=3.11)
- conda auto-installation used environment.yml with `python<=3.10`

## Changes
- `smoke-test.yml`: Python matrix `3.10/3.11/3.12` → `3.11/3.12/3.13`
- `environment.yml`: `python>=3.8, <= 3.10` → `python>=3.11`